### PR TITLE
Bump upstream source code to 2022.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Xiaomi Mi Electric Rice Cooker
 
+![GitHub actions](https://github.com/syssi/xiaomi_cooker/actions/workflows/ci.yaml/badge.svg)
+![GitHub stars](https://img.shields.io/github/stars/syssi/xiaomi_cooker)
+![GitHub forks](https://img.shields.io/github/forks/syssi/xiaomi_cooker)
+![GitHub watchers](https://img.shields.io/github/watchers/syssi/xiaomi_cooker)
+[!["Buy Me A Coffee"](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg)](https://www.buymeacoffee.com/syssi)
+
 This is a custom component for home assistant to integrate the Xiaomi Mi Electric Rice Cooker V2.
 
 Please follow the instructions on [Retrieving the Access Token](https://home-assistant.io/components/xiaomi/#retrieving-the-access-token) to get the API token to use in the configuration.yaml file.
@@ -161,7 +167,6 @@ The following is an advanced example for a configuration of chunmi.cooker.eh1 su
 
 ```yaml
 # lovelace
-
 type: vertical-stack
 title: Multi Cooker
 cards:
@@ -235,7 +240,6 @@ cards:
 
 ```yaml
 # configuration.yaml
-
 sensor:
   - platform: template
     sensors:
@@ -265,17 +269,14 @@ sensor:
               "0505000000000000000000000000000000000009": "Cake"
             }[states('sensor.xiaomi_miio_cooker_menu')]
           }}
-
 input_datetime:
   rice_cooker_schedule_time:
     name: Time
     has_time: true
     has_date: true
-
 input_boolean:
   rice_cooker_schedule:
     name: Schedule
-
 input_select:
     cooker_programm:
       name: Modus
@@ -291,7 +292,6 @@ input_select:
 
 ```yaml
 # scripts.yaml
-
 rice_cooker_start:
   alias: StartRiceCooker
   sequence:
@@ -317,7 +317,6 @@ rice_cooker_start:
     data: {}
     entity_id: input_boolean.rice_cooker_schedule
   mode: single
-
 rice_cooker_stop:
   alias: StopRiceCooker
   sequence:

--- a/custom_components/xiaomi_miio_cooker/__init__.py
+++ b/custom_components/xiaomi_miio_cooker/__init__.py
@@ -1,18 +1,9 @@
-import asyncio
 import logging
-from collections import defaultdict
 from datetime import timedelta
-from functools import partial
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_SCAN_INTERVAL,
-    CONF_TOKEN,
-)
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL, CONF_TOKEN
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import discovery
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -106,7 +97,7 @@ def setup(hass, config):
 
     host = config[DOMAIN][CONF_HOST]
     token = config[DOMAIN][CONF_TOKEN]
-    name = config[DOMAIN][CONF_NAME]
+    # name = config[DOMAIN][CONF_NAME]
     model = config[DOMAIN].get(CONF_MODEL)
     scan_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
 
@@ -233,8 +224,8 @@ class XiaomiMiioDevice(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes of the device."""
+    def extra_state_attributes(self):
+        """Return the extra state attributes of the device."""
         return self._state_attrs
 
 

--- a/custom_components/xiaomi_miio_cooker/manifest.json
+++ b/custom_components/xiaomi_miio_cooker/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "xiaomi_miio_cooker",
   "name": "Xiaomi Mi Electric Rice Cooker",
-  "version": "0.2.5",
+  "version": "2022.3.0",
   "iot_class": "local_polling",
   "config_flow": false,
   "documentation": "https://github.com/syssi/xiaomi_cooker",
   "issue_tracker": "https://github.com/syssi/xiaomi_cooker/issues",
   "requirements": [
     "construct==2.10.56",
-    "git+https://github.com/sschirr/python-miio.git@master#python-miio==0.5.6+sschirrdev"
+    "git+https://github.com/sschirr/python-miio.git@master#python-miio==0.5.10+sschirrdev"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
This makes it working again with HA 2022.3 by bumping the source code of the upstream code from syssi
It got broken due to wrong dependencies.

Also it has dependencies to https://github.com/FaserF/python-miio/commit/b75dd82a9555a25dcec0120543ac0d2ed9225acd but I cant create a pull request at your python-miio repo (most likely as you already have opened a pull request at rytilahti repo and both are in the "main" branch.